### PR TITLE
listen for and communicate request failures

### DIFF
--- a/src/clj/qbits/jet/client/http.clj
+++ b/src/clj/qbits/jet/client/http.clj
@@ -328,6 +328,11 @@
                                                            ^HttpFields (.getHeaders response))
                                                    body-ch)))))
 
+    (.onRequestFailure request
+                       (reify Request$FailureListener
+                         (onFailure [_ _ throwable]
+                           (async/put! ch {:error throwable}))))
+
     (.send request
            (reify Response$CompleteListener
              (onComplete [this result]


### PR DESCRIPTION
I noticed jet was dropping requests when Jetty hit OOM trying to allocate new threads; you simply never heard back on the response channel.

There was an unused import for Request$FailureListener, so I believe this change was someone's intent at some point. Now you get the OOM exception back:

```
; with -Xmx32m
user=> (require '[qbits.jet.client.http :as jet])
nil
user=> (def c (jet/client))
'user/c
user=> (require '[clojure.core.async :as a])
nil
user=> (def cs (mapv (fn [_] (jet/get c "http://httpbin.org/delay/5")) (range 0 100)))
#'user/cs
user=> (mapv a/<!! cs)
[{:error #error {
 :cause "Java heap space"
 :via
 [{:type java.lang.OutOfMemoryError
   :message "Java heap space"
   :at nil}]
 :trace
 []}} {:error #error {
 :cause "Java heap space"
 :via
 [{:type java.lang.OutOfMemoryError
   :message "Java heap space"
   :at nil}]
 :trace
 []}} 
...
```