### PR TITLE
server: allow specifying parser compliance

### DIFF
--- a/src/clj/qbits/jet/server.clj
+++ b/src/clj/qbits/jet/server.clj
@@ -132,9 +132,9 @@ Derived from ring.adapter.jetty"
   [pc]
   (cond
     (instance? HttpCompliance pc) pc
-    (= pc :parser-legacy)         HttpCompliance/LEGACY
-    (= pc :parser-rfc2616)        HttpCompliance/RFC2616
-    (= pc :parser-rfc7230)        HttpCompliance/RFC7230
+    (= pc :legacy)                HttpCompliance/LEGACY
+    (= pc :rfc2616)               HttpCompliance/RFC2616
+    (= pc :rfc7230)               HttpCompliance/RFC7230
     (nil? pc)                     HttpCompliance/RFC7230
     :else                         (throw (ex-info "Illegal Http Parser" {}))))
 


### PR DESCRIPTION
By default, Jetty standardizes headers to benefit from using a cache.
Previously, this was overridable through the `org.eclipse.jetty.http.HttpParser.STRICT' system property.

In recent jetty releases this isn't the case and breaks signing mechanisms which rely on case-sensitive encoding of Http headers.

This PR brings back the ability to get original HTTP header values.